### PR TITLE
fix(KONFLUX-6218): align repository ids to cpe mapping

### DIFF
--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -5,56 +5,56 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/jq-1.6-9.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream-rpms
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 207896
     checksum: sha256:baaa3660d87c4f3c12776e051b7f13835fee8918389a57673519e3389eb7aa3b
     name: jq
     evr: 1.6-9.el8_10
     sourcerpm: jq-1.6-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/o/oniguruma-6.8.2-3.el8.x86_64.rpm
-    repoid: ubi-8-appstream-rpms
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 192632
     checksum: sha256:1c5c91d8a33987892ec7320c08311a31245be91800aa5879e20d137971bd053f
     name: oniguruma
     evr: 6.8.2-3.el8
     sourcerpm: oniguruma-6.8.2-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/w/wget-1.19.5-12.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream-rpms
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 751872
     checksum: sha256:8d609774711cea9728faf684ff7e9b389f0f3c2052aa04bcf3061950a830058b
     name: wget
     evr: 1.19.5-12.el8_10
     sourcerpm: wget-1.19.5-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/e/expat-2.2.5-16.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 117296
     checksum: sha256:c7783e000326c94f8aed71f1b18eba0b46cb556e8a31900b99b5541ee865a1d8
     name: expat
     evr: 2.2.5-16.el8_10
     sourcerpm: expat-2.2.5-16.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libmetalink-0.1.3-7.el8.x86_64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 32784
     checksum: sha256:cd7c30d21e7240f60f0861c229e17fda43e855ab4c78fab39f47f7ae2be5720e
     name: libmetalink
     evr: 0.1.3-7.el8
     sourcerpm: libmetalink-0.1.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libsemanage-2.9-10.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 172692
     checksum: sha256:a4223fd87cf94bc62f719ca1b3c82c3af28caf83bc55c587ad81136bf798e96b
     name: libsemanage
     evr: 2.9-10.el8_10
     sourcerpm: libsemanage-2.9-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/s/shadow-utils-4.6-22.el8.x86_64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 1292332
     checksum: sha256:ea73ee201451bbca0d6d14ca434c93800f01c8fb1b9daef727a5af1a27356d07
     name: shadow-utils
     evr: 2:4.6-22.el8
     sourcerpm: shadow-utils-4.6-22.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/u/unzip-6.0-47.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos-rpms
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 200440
     checksum: sha256:99e1415de872d65a36b89c2d646d66fa2d7b7d9ee34d4e1e24a9b00716c68c73
     name: unzip

--- a/ubi.repo
+++ b/ubi.repo
@@ -47,14 +47,6 @@ enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[codeready-builder-for-ubi-8-x86_64-rpms]
-name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/os
-enabled = 0
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-gpgcheck = 1
-
-
 [codeready-builder-for-ubi-8-x86_64-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/debug

--- a/ubi.repo
+++ b/ubi.repo
@@ -1,70 +1,70 @@
-[ubi-8-baseos-rpms]
+[ubi-8-for-x86_64-baseos-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-debug-rpms]
+[ubi-8-for-x86_64-baseos-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/debug
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-source]
+[ubi-8-for-x86_64-baseos-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/source/SRPMS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/source/SRPMS
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-rpms]
+[ubi-8-for-x86_64-appstream-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - AppStream
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-debug-rpms]
+[ubi-8-for-x86_64-appstream-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/debug
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-source]
+[ubi-8-for-x86_64-appstream-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/source/SRPMS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/source/SRPMS
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-rpms]
+[codeready-builder-for-ubi-8-x86_64-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder]
+[codeready-builder-for-ubi-8-x86_64-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/os
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
 
-[ubi-8-codeready-builder-debug-rpms]
+[codeready-builder-for-ubi-8-x86_64-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/debug
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-source]
+[codeready-builder-for-ubi-8-x86_64-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
-baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/source/SRPMS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/codeready-builder/source/SRPMS
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1


### PR DESCRIPTION
This update changes the rpm repository ids to match those found in Red Hat's [repository-to-cpe.json](https://security.access.redhat.com/data/meta/v1/repository-to-cpe.json) mapping file, used by third-party scanners.

In order for scanners like clair to understand what [CPE](https://cpe.mitre.org/) a Red Hat rpm is associated with, it needs to be able to find its repository in Red Hat's published mapping file.

Even though some "arch-less" repository ids currently appear in the mapping file, they are going to be removed soon and will be blocked by Konflux in the future in https://github.com/release-engineering/rhtap-ec-policy/pull/99.