### PR TITLE
[RHOAIENG-20044] - Resolve CVE Violations - odh-modelmesh-v2-18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
     <grpc-version>1.60.2</grpc-version>
-    <netty-version>4.1.108.Final</netty-version>
+    <netty-version>4.1.118.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.24</etcd-java-version>


### PR DESCRIPTION
chore:	Fix [CVE-2025-24970](https://github.com/advisories/GHSA-4g8c-wm8x-jfhw)
	SslHandler doesn't correctly validate packets which can lead to native crash when using native SSLEngine

#### Motivation


#### Modifications


#### Result
