### PR TITLE
add dockerfile context for rpms.in.yaml

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -6,3 +6,5 @@ packages:
   - jq
   - wget
   - shadow-utils
+context:
+    containerfile: ./Dockerfile.konflux


### PR DESCRIPTION
this is needed because of the nonstandard dockerfile name
