### PR TITLE
[Cherry-pick][RHOAIENG-32171] Fix CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
     <grpc-version>1.63.2</grpc-version>
-    <netty-version>4.1.118.Final</netty-version>
+    <netty-version>4.1.124.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.24</etcd-java-version>


### PR DESCRIPTION
chore: Fix [CVE-2025-55163](https://github.com/netty/netty/security/advisories/GHSA-prj3-ccx8-p6x4)

Netty is vulnerable to a MadeYouReset HTTP/2 DDoS attack. Malformed control frames can bypass the max concurrent streams limit, leading to resource exhaustion and a denial of service.

#### Motivation


#### Modifications


#### Result
