### PR TITLE
[Cherry-pick][RHOAIENG-32165] Fix CVE-2025-55163

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,10 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+    </dependency>
 
     <!-- This is required for compiling on java11+, to provide
        the @Generated annotation used in the protoc-generated


### PR DESCRIPTION
chore: Fix [CVE-2025-55163](https://github.com/netty/netty/security/advisories/GHSA-prj3-ccx8-p6x4)

Netty is vulnerable to a MadeYouReset HTTP/2 DDoS attack. Malformed control frames can bypass the max concurrent streams limit, leading to resource exhaustion and a denial of service.

#### Motivation


#### Modifications


#### Result
