### PR TITLE
[RHOAIENG-33932] Fix CVE-2025-58056

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
     <grpc-version>1.63.2</grpc-version>
-    <netty-version>4.1.124.Final</netty-version>
+    <netty-version>4.1.125.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.24</etcd-java-version>


### PR DESCRIPTION
chore: Fix [CVE-2025-58056 ](https://github.com/netty/netty/security/advisories/GHSA-fghv-69vj-qj49)

Netty is vulnerable to request smuggling due to incorrect parsing of chunk extensions
