### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-modelmesh-v2-23

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -24,7 +24,8 @@ ARG VERSION
 ARG USERID=2000
 
 LABEL com.redhat.component="odh-modelmesh-container" \
-      name="managed-open-data-hub/odh-modelmesh-rhel8" \
+      name="rhoai/odh-modelmesh-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.23::el9" \
       description="Modelmesh is a distributed LRU cache for serving runtime models" \
       summary="odh-modelmesh" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
