### PR TITLE
[RHOAIENG-33671] CVE-2025-57852: Openshift-ai: privilege escalation v…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,9 +115,6 @@ RUN --mount=type=cache,target=/root/.cache/microdnf:rw \
     # Create app user
     && useradd -c "Application User" -U -u ${USER} -m app \
     && chown -R app:0 /home/app \
-    # Adjust permissions on /etc/passwd to be writable by group root.
-    # The user app is replaced by the assigned UID on OpenShift.
-    && chmod g+w /etc/passwd \
     # In newer Docker there is a --chown option for the COPY command
     && ln -s /opt/kserve/mmesh /opt/kserve/tas \
     && mkdir -p log \

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -48,7 +48,6 @@ RUN echo "${VERSION}"
 
 RUN useradd -c "Application User" -U -u ${USERID} -m app && \
     chown -R app:0 /home/app && \
-    chmod g+w /etc/passwd && \
     ln -s /opt/kserve/mmesh /opt/kserve/tas && \
     mkdir -p log && \
     chown -R app:0 . && \


### PR DESCRIPTION
…ia excessive /etc/passwd permissions

chore:  Fix [CVE-2025-57852](https://www.cve.org/CVERecord?id=CVE-2025-57852)

#### Motivation


#### Modifications


#### Result
