### PR TITLE
cherry-pick: Fix CWE-918: Add SSRF protection to RemotePayloadProcessor

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -16,7 +16,9 @@
 
 package com.ibm.watson.modelmesh.payload;
 
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -44,9 +46,118 @@ public class RemotePayloadProcessor implements PayloadProcessor {
 
     private final HttpClient client;
 
+    /**
+     * Validates the URI to prevent SSRF attacks by rejecting requests to private/internal networks.
+     *
+     * @param uri The URI to validate
+     * @throws IllegalArgumentException if the URI points to a private or internal network
+     */
+    private static void validateUri(URI uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("URI cannot be null");
+        }
+
+        // Validate scheme - only http and https are allowed
+        String scheme = uri.getScheme();
+        if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
+            throw new IllegalArgumentException("URI scheme must be http or https, got: " + scheme);
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            throw new IllegalArgumentException("URI must have a valid host");
+        }
+
+        // Reject localhost and loopback addresses (string-based checks for bypasses)
+        String hostLower = host.toLowerCase();
+
+        // Check common localhost variants
+        if (hostLower.equals("localhost") ||
+            hostLower.equals("127.0.0.1") ||
+            hostLower.equals("::1") ||
+            hostLower.equals("0.0.0.0") ||
+            hostLower.equals("[::]") ||
+            hostLower.equals("::") ||
+            hostLower.startsWith("127.") ||
+            hostLower.startsWith("0x7f.")) {  // hex-encoded 127
+            throw new IllegalArgumentException("URI cannot point to localhost or loopback address: " + host);
+        }
+
+        // Check for octal-encoded localhost (0177.0.0.1, etc.)
+        if (hostLower.matches("0[0-7]+\\..*") || hostLower.matches(".*\\.0[0-7]+\\..*")) {
+            throw new IllegalArgumentException("URI cannot use octal IP encoding: " + host);
+        }
+
+        // Try to resolve the host and perform additional validation
+        // Per OWASP SSRF Prevention: Check ALL resolved IPs to prevent DNS pinning attacks
+        // If the host can't be resolved, allow it to pass (the HTTP request will fail later)
+        try {
+            InetAddress[] allAddresses = InetAddress.getAllByName(host);
+
+            // Validate each resolved IP address (prevents DNS pinning bypass)
+            for (InetAddress addr : allAddresses) {
+                byte[] addrBytes = addr.getAddress();
+
+                // Reject private IP ranges (RFC 1918)
+                if (addr.isSiteLocalAddress()) {
+                    throw new IllegalArgumentException("URI resolves to private IP address: " + addr.getHostAddress());
+                }
+
+                // Reject loopback addresses
+                if (addr.isLoopbackAddress()) {
+                    throw new IllegalArgumentException("URI resolves to loopback address: " + addr.getHostAddress());
+                }
+
+                // Reject link-local addresses (includes AWS metadata service at 169.254.169.254)
+                if (addr.isLinkLocalAddress()) {
+                    throw new IllegalArgumentException("URI resolves to link-local address: " + addr.getHostAddress());
+                }
+
+                // Reject multicast addresses
+                if (addr.isMulticastAddress()) {
+                    throw new IllegalArgumentException("URI resolves to multicast address: " + addr.getHostAddress());
+                }
+
+                // Additional check for 0.0.0.0
+                if (addr.isAnyLocalAddress()) {
+                    throw new IllegalArgumentException("URI resolves to wildcard address: " + addr.getHostAddress());
+                }
+
+                // Reject IPv6 unique local addresses (RFC 4193: fc00::/7)
+                if (addrBytes.length == 16 && (addrBytes[0] & 0xfe) == 0xfc) {
+                    throw new IllegalArgumentException("URI resolves to IPv6 unique local address (RFC 4193): " + addr.getHostAddress());
+                }
+            }
+
+        } catch (UnknownHostException e) {
+            // If the host can't be resolved, allow it to continue
+            // The actual HTTP request will fail later with a proper error
+            logger.warn("Unable to resolve host for SSRF validation: {}", host);
+        }
+    }
+
     public RemotePayloadProcessor(URI uri) {
+        this(uri, null, null);
+    }
+
+    public RemotePayloadProcessor(URI uri, SSLContext sslContext, SSLParameters sslParameters) {
+        validateUri(uri);
         this.uri = uri;
-        this.client = HttpClient.newHttpClient();
+        this.sslContext = sslContext;
+        this.sslParameters = sslParameters;
+        if (sslContext != null && sslParameters != null) {
+            // OWASP SSRF Prevention: Explicitly disable HTTP redirects to prevent bypass
+            this.client = HttpClient.newBuilder()
+                    .sslContext(sslContext)
+                    .sslParameters(sslParameters)
+                    .followRedirects(HttpClient.Redirect.NEVER)
+                    .build();
+        } else {
+            // OWASP SSRF Prevention: Explicitly disable HTTP redirects to prevent bypass
+            this.client = HttpClient.newBuilder()
+                    .followRedirects(HttpClient.Redirect.NEVER)
+                    .build();
+        }
     }
 
     @Override

--- a/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
@@ -25,6 +25,7 @@ import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RemotePayloadProcessorTest {
 
@@ -41,5 +42,131 @@ class RemotePayloadProcessorTest {
         ByteBuf data = Unpooled.buffer(4);
         Payload payload = new Payload(id, modelId, method, metadata, data, kind);
         assertFalse(remotePayloadProcessor.process(payload));
+    }
+
+    @Test
+    void testSSRFProtection_Localhost() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://localhost:8080/endpoint"));
+        }, "Should reject localhost");
+    }
+
+    @Test
+    void testSSRFProtection_LoopbackIPv4() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://127.0.0.1:8080/endpoint"));
+        }, "Should reject 127.0.0.1");
+    }
+
+    @Test
+    void testSSRFProtection_LoopbackIPv6() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://[::1]:8080/endpoint"));
+        }, "Should reject ::1");
+    }
+
+    @Test
+    void testSSRFProtection_PrivateIP_10() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://10.0.0.1:8080/endpoint"));
+        }, "Should reject 10.x.x.x private IP");
+    }
+
+    @Test
+    void testSSRFProtection_PrivateIP_192() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://192.168.1.1:8080/endpoint"));
+        }, "Should reject 192.168.x.x private IP");
+    }
+
+    @Test
+    void testSSRFProtection_PrivateIP_172() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://172.16.0.1:8080/endpoint"));
+        }, "Should reject 172.16-31.x.x private IP");
+    }
+
+    @Test
+    void testSSRFProtection_AWSMetadata() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://169.254.169.254/latest/meta-data/"));
+        }, "Should reject AWS metadata service");
+    }
+
+    @Test
+    void testSSRFProtection_NullURI() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(null);
+        }, "Should reject null URI");
+    }
+
+    @Test
+    void testSSRFProtection_EmptyHost() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://:8080/endpoint"));
+        }, "Should reject empty host");
+    }
+
+    @Test
+    void testSSRFProtection_IPv6AllZeros() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://[::]:8080/endpoint"));
+        }, "Should reject IPv6 all zeros [::]");
+    }
+
+    @Test
+    void testSSRFProtection_OctalIPEncoding() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://0177.0.0.1:8080/endpoint"));
+        }, "Should reject octal-encoded localhost (0177.0.0.1)");
+    }
+
+    @Test
+    void testSSRFProtection_HexIPEncoding() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://0x7f.0.0.1:8080/endpoint"));
+        }, "Should reject hex-encoded localhost (0x7f.0.0.1)");
+    }
+
+    @Test
+    void testSSRFProtection_IPv6UniqueLocal() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://[fc00::1]:8080/endpoint"));
+        }, "Should reject IPv6 unique local address (fc00::/7)");
+    }
+
+    @Test
+    void testSSRFProtection_IPv6UniqueLocal_fd() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://[fd12:3456:789a:1::1]:8080/endpoint"));
+        }, "Should reject IPv6 unique local address (fd00::/8)");
+    }
+
+    @Test
+    void testSSRFProtection_InvalidScheme_FTP() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("ftp://example.com/file"));
+        }, "Should reject ftp scheme");
+    }
+
+    @Test
+    void testSSRFProtection_InvalidScheme_File() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("file:///etc/passwd"));
+        }, "Should reject file scheme");
+    }
+
+    @Test
+    void testSSRFProtection_InvalidScheme_Gopher() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("gopher://example.com/"));
+        }, "Should reject gopher scheme");
+    }
+
+    @Test
+    void testSSRFProtection_WildcardIPv4() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new RemotePayloadProcessor(URI.create("http://0.0.0.0:8080/endpoint"));
+        }, "Should reject 0.0.0.0");
     }
 }


### PR DESCRIPTION
cherry-pick of pr https://github.com/red-hat-data-services/modelmesh/pull/940

Fix CWE-918: Add SSRF protection to RemotePayloadProcessor
  - Added URI validation to prevent Server-Side Request Forgery (CWE-918)
  - Blocks requests to localhost, loopback, private IPs, and link-local addresses
  - Prevents access to cloud metadata services 
  - Added comprehensive tests for SSRF protection
