### PR TITLE
[RHOAIENG-56072] CVE-2026-33871: Bump Netty to 4.1.132.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
     <grpc-version>1.63.2</grpc-version>
-    <netty-version>4.1.125.Final</netty-version>
+    <netty-version>4.1.132.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.24</etcd-java-version>


### PR DESCRIPTION
## Summary
- Bumps `io.netty` BOM from **4.1.125.Final** to **4.1.132.Final** to fix CVE-2026-33871 (Netty HTTP/2 CONTINUATION frame flood DoS, CVSS 7.5 HIGH)
- The `netty-bom` import in `dependencyManagement` ensures all transitive Netty artifacts are updated uniformly

## JIRA
- https://redhat.atlassian.net/browse/RHOAIENG-56072
- https://redhat.atlassian.net/browse/RHOAIENG-56065

## Verification
- `mvn clean package -DskipTests` — BUILD SUCCESS
- `mvn clean package` — compilation succeeds; test failures are pre-existing infrastructure issues (ZooKeeper/port binding), unrelated to this change

## Note
rhoai-2.16 already has Netty 4.1.132.Final — this PR fixes only `main`.