### PR TITLE
fix: CVE-2026-24308 via ZooKeeper update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,6 @@
     <zookeeper-version>3.8.4</zookeeper-version>
     <curator-version>5.3.0</curator-version>
 
-    <zookeeper-version>3.7.2</zookeeper-version>
-    <curator-version>5.3.0</curator-version>
-
     <dockerhome>${project.build.directory}/dockerhome</dockerhome>
     <skipTests>false</skipTests>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <bouncycastle-version>1.78</bouncycastle-version>
     <junit-version>5.10.2</junit-version>
 
-    <zookeeper-version>3.8.4</zookeeper-version>
+    <zookeeper-version>3.8.6</zookeeper-version>
     <curator-version>5.3.0</curator-version>
 
     <dockerhome>${project.build.directory}/dockerhome</dockerhome>


### PR DESCRIPTION
Fix CVE-2026-24308 by applying two changes:
* Commit b42d511: fix duplicated entries in pom.xml
- Commit 1c10758: Cherry-pick opendatahub-io/modelmesh#119, which updates Zookeeper to a version that addresses CVE-2026-24308 (despite the PR addressing another CVE).

Related: https://redhat.atlassian.net/browse/RHOAIENG-59190