### PR TITLE
[RHOAIENG-52643] Fix duplicate zookeeper-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,6 @@
     <zookeeper-version>3.8.6</zookeeper-version>
     <curator-version>5.3.0</curator-version>
 
-    <zookeeper-version>3.7.2</zookeeper-version>
-    <curator-version>5.3.0</curator-version>
-
     <dockerhome>${project.build.directory}/dockerhome</dockerhome>
     <skipTests>false</skipTests>
   </properties>


### PR DESCRIPTION
## Summary
- A merge from `upstream/stable-2.x` introduced a duplicate `<zookeeper-version>` property in `pom.xml`
- Maven uses last-definition-wins, so the duplicate `3.7.2` entry silently overrode the `3.8.6` CVE fix (CVE-2026-24281)
- The shipped `rhoai/odh-modelmesh-rhel9:v2.25.6` image contains `zookeeper-3.7.2.jar`, confirming the vulnerability is still present
- This PR removes the duplicate block so the correct `3.8.6` version takes effect

## Test plan
- [ ] Verify `pom.xml` has only one `<zookeeper-version>` entry set to `3.8.6`
- [ ] Verify built image contains `zookeeper-3.8.6.jar`

🤖 Generated with [Claude Code](https://claude.ai/code)